### PR TITLE
Fix test GitHub action

### DIFF
--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -28,8 +28,8 @@ jobs:
 
       - name: Installing Nextflow
         run: |
-          sudo apt-get install wget
-          sudo apt-get install default-jdk
+          sudo apt-get update
+          sudo apt-get install wget default-jdk
           sudo wget -qO- https://get.nextflow.io | bash
           sudo mv nextflow /usr/bin
             


### PR DESCRIPTION
While executing the GitHub action to test ksrates, an intermediate step (installing Nextflow) was asking to run "apt-get update" and stopping the action; after adding this line, the GitHub action could reach the end. 