### PR TITLE
Improve checkpoint for divergence colors provided in configuration file

### DIFF
--- a/ksrates/fc_configfile.py
+++ b/ksrates/fc_configfile.py
@@ -2,6 +2,7 @@ import configparser
 import os
 from ete3 import Tree
 import ksrates.fc_check_input as fcCheck
+from matplotlib.colors import is_color_like
 import logging
 import sys
 from ast import literal_eval
@@ -458,6 +459,8 @@ class Configuration:
         is assigned to the second internal node encountered along this path, and so on.
         There must be at least as many colors as the number of divergence nodes.
 
+        Checks if there are colors whose name is not recognized by matplotlib, e.g. misspelled.
+
         :return colors: list of colors
         """
         color_list_string = self.config.get("PARAMETERS", "divergence_colors")
@@ -466,6 +469,17 @@ class Configuration:
             logging.error('Field "divergence_colors" in configuration file is empty, please fill in')
             logging.error("Exiting.")
             sys.exit(1)
+
+        # Check if color names are recognized by matplotlib
+        faulty_color_names = []
+        for color in colors:
+            if not is_color_like(color):
+                faulty_color_names.append(color)
+        if len(faulty_color_names) != 0:
+            logging.error('Field "divergence_colors" in configuration file contains color names not recognized by Matplotlib, please adjust the following:')
+            for color in faulty_color_names:
+                logging.error(f"- {color}")
+            sys.exit(1)            
         return colors
 
 

--- a/ksrates/fc_configfile.py
+++ b/ksrates/fc_configfile.py
@@ -106,10 +106,10 @@ class Configuration:
         """
         species = self.config.get("SPECIES", "focal_species")
         if species == "":
-            logging.error("Parameter focal_species in configuration file is empty, please fill in")
+            logging.error('Field "focal_species" in configuration file is empty, please fill in')
             sys.exit(1)
-        elif len(species.split()) != 1:
-            logging.error(f"Parameter focal_species [{species}] should be a short name and must not contain any spaces, please change accordingly")
+        elif len(species.split()) != 1 or "_" in species:
+            logging.error(f'Field "focal_species" [{species}] should be a short name and must not contain any spaces or underscores, please change accordingly')
             sys.exit(1)
         return species
 
@@ -123,13 +123,13 @@ class Configuration:
         tree_string = self.config.get("SPECIES", "newick_tree")
         if not (tree_string.endswith(';')):
             tree_string += ";"
-        if tree_string == "();":
-            logging.error("Parameter newick_tree in configuration file is empty, please fill in")
+        if tree_string == "();" or tree_string == ";":
+            logging.error('Field "newick_tree" in configuration file is empty, please fill in')
             sys.exit(1)
         try:
             tree = Tree(tree_string)
         except Exception:
-            logging.error("Unrecognized format for parameter newick_tree in configuration file (for example, parentheses do not match)")
+            logging.error('Unrecognized format for field "newick_tree" in configuration file (for example, parentheses do not match)')
             sys.exit(1)
 
         # Check if species' informal names contain illegal characters (underscore or spaces)
@@ -157,9 +157,9 @@ class Configuration:
         missing_species = list(set.difference(set(all_leaves), set(dictionary.keys())))
         if len(missing_species) != 0:
             if len(missing_species) == 1:
-                logging.error(f"The following species is missing from the [latin_names] configuration file field:")
+                logging.error(f'The following species is missing from the "latin_names" configuration file field:')
             else:
-                logging.error(f"The following species are missing from the [latin_names] configuration file field:")
+                logging.error(f'The following species are missing from the "latin_names" configuration file field:')
             for missing_name in missing_species:
                 logging.error(f" - {missing_name}")
             
@@ -177,7 +177,7 @@ class Configuration:
         if latin_names != "":
             latin_names_dict = self._get_clean_dict_stringent(latin_names, "latin_names")
         else:
-            logging.error("Configuration file field [latin_names] is empty, please fill in and restart the analysis.")
+            logging.error('Configuration file field "latin_names" is empty, please fill in and restart the analysis.')
             logging.error("Exiting.")
             sys.exit(1)
         # Check if latin_names contains all the species present in the Newick tree; if not, exits
@@ -689,12 +689,12 @@ class Configuration:
                     logging.warning(f'Unrecognized field in expert configuration file [max_mixture_model_components = {max_comp}]. Please choose a positive integer >= 2. Default choice will be applied [5]')  
                     max_comp = 5
                 elif max_comp == 1:
-                    logging.warning(f"Parameter [max_mixture_model_components] has been changed from {max_comp} to the minimum required, 2.")
+                    logging.warning(f'Field "max_mixture_model_components" has been changed from {max_comp} to the minimum required, 2')
                     max_comp = 2 # exponential + buffer
                 elif max_comp <= 3:
-                    logging.warning(f"A low number of mixture model components [max_mixture_model_components = {max_comp}] can produce poor fitting.")
+                    logging.warning(f"A low number of mixture model components [max_mixture_model_components = {max_comp}] can produce poor fitting")
                 elif max_comp >= 7:
-                    logging.warning(f"A high number of mixture model components [max_mixture_model_components = {max_comp}] increases overfitting risk.")
+                    logging.warning(f"A high number of mixture model components [max_mixture_model_components = {max_comp}] increases overfitting risk")
             except Exception:
                 logging.warning(f'Missing field in expert configuration file [max_mixture_model_components]. Please choose a positive integer. Default choice will be applied [5]')
                 max_comp = 5

--- a/ksrates/fc_configfile.py
+++ b/ksrates/fc_configfile.py
@@ -462,6 +462,10 @@ class Configuration:
         """
         color_list_string = self.config.get("PARAMETERS", "divergence_colors")
         colors = [c.strip() for c in color_list_string.split(',')]
+        if len(colors) == 1 and colors[0] == "":
+            logging.error('Field "divergence_colors" in configuration file is empty, please fill in')
+            logging.error("Exiting.")
+            sys.exit(1)
         return colors
 
 


### PR DESCRIPTION
- Module `fc_configfile.py` now warns and exits if `divergence_colors` configuration file field was left empty or if the color names are not recognized by matplotlib (e.g. misspelled names)
- Module `setup_correction.py` now checks whether the amount of colors provided in the configuration file field `divergence_colors` is enough: it must be at least equal to the number of divergence nodes in the lineage that goes from the focal species back to to the second-to-last divergence node before the root (the root node is ignored because the divergence(s) at this node will not be rate-adjusted). This way there are enough colors to depict all of the divergence lines in the mixed Ks plot.
- Few other edits made to match the general style of logging messages