### PR TITLE
Add warning for negative distances during rate-adjustment

### DIFF
--- a/ksrates/fc_rrt_correction.py
+++ b/ksrates/fc_rrt_correction.py
@@ -1,4 +1,5 @@
 from math import sqrt
+import logging
 
 # Filenames
 _ADJUSTMENT_TABLE_ALL = "adjustment_table_{}_all.tsv"
@@ -44,6 +45,23 @@ def decompose_ortholog_ks(ortholog_db, idx_species_sister, idx_species_outgroup,
     # Error propagation rules
     rel_rate_species_sd = sqrt(pow(sd_sp_out, 2) + pow(sd_sp_sis, 2) + pow(sd_sis_out, 2)) / 2.0 # also called k_AO_sd
     rel_rate_sister_sd = sqrt(pow(sd_sp_sis, 2) + pow(sd_sis_out, 2) + pow(sd_sp_out, 2)) / 2.0 # also called k_BO_sd
+
+    focal_species = idx_species_sister.split("_")[0]
+    sister_species = idx_species_sister.split("_")[1]
+    if rel_rate_species < 0:
+        logging.warning(f"ksrates has returned a negative number for the genetic distance accumulated by focal species [{focal_species}] since the divergence with sister species {sister_species} ('K_OA' segment, see Supplementary materials).")
+    elif rel_rate_sister < 0:
+        logging.warning(f"ksrates has returned a negative number for the genetic distance accumulated by sister species {sister_species} since the divergence with focal species [{focal_species}] ('K_OB' segment, see Supplementary materials).")
+    if rel_rate_species < 0 or rel_rate_sister < 0:
+        logging.warning("This is an artefact due to poor estimation of the ortholog peaks that are used as input data for the rate-adjustment formulas.")
+        logging.warning("Poor estimation is often due to the very old divergence age between the two chosen species and/or outgroup, or by bad genome/sequence quality.")
+        logging.warning("It is thus recommended to check the ortholog distributions and their peak estimates in the 'orthologs_species1_species2.pdf' output files.")
+        logging.warning("")
+        logging.warning("TIPS! Try rerunning your analysis with one or more of the following changes:")
+        logging.warning(" - limit the number of outgroups by decreasing 'max_number_outgroups' (default is 4)")
+        logging.warning(" - set 'consensus_mode_for_multiple_outgroups' to 'best outgroup'")
+        logging.warning(" - exclude very old divergences from the input phylogeny")
+        logging.warning("")
 
     return rel_rate_species, rel_rate_species_sd, rel_rate_sister, rel_rate_sister_sd
 

--- a/ksrates/fc_rrt_correction.py
+++ b/ksrates/fc_rrt_correction.py
@@ -48,19 +48,33 @@ def decompose_ortholog_ks(ortholog_db, idx_species_sister, idx_species_outgroup,
 
     focal_species = idx_species_sister.split("_")[0]
     sister_species = idx_species_sister.split("_")[1]
+    
+    # Checkpoint to spot negative Ks distances for the focal and/or sister species.
+    # Prints a warning, doesn't stop the pipeline
     if rel_rate_species < 0:
-        logging.warning(f"ksrates has returned a negative number for the genetic distance accumulated by focal species [{focal_species}] since the divergence with sister species {sister_species} ('K_OA' segment, see Supplementary materials).")
-    elif rel_rate_sister < 0:
-        logging.warning(f"ksrates has returned a negative number for the genetic distance accumulated by sister species {sister_species} since the divergence with focal species [{focal_species}] ('K_OB' segment, see Supplementary materials).")
+        logging.warning("")
+        logging.warning(f"ksrates has returned a negative number ({round(rel_rate_species, 5)}) for the genetic distance accumulated by")
+        logging.warning(f"focal species [{focal_species}] since its divergence with sister species {sister_species}")
+        logging.warning(f"(refer to the 'K_OA' segment in Supplementary materials).")
+    if rel_rate_sister < 0:
+        logging.warning("")
+        logging.warning(f"ksrates has returned a negative number ({round(rel_rate_sister, 5)}) for the genetic distance accumulated by")
+        logging.warning(f"sister species {sister_species} since its divergence with focal species [{focal_species}]")
+        logging.warning(f"(refer to the 'K_OB' segment in Supplementary materials).")
     if rel_rate_species < 0 or rel_rate_sister < 0:
-        logging.warning("This is an artefact due to poor estimation of the ortholog peaks that are used as input data for the rate-adjustment formulas.")
-        logging.warning("Poor estimation is often due to the very old divergence age between the two chosen species and/or outgroup, or by bad genome/sequence quality.")
-        logging.warning("It is thus recommended to check the ortholog distributions and their peak estimates in the 'orthologs_species1_species2.pdf' output files.")
+        logging.warning("")
+        logging.warning("Negative distances are an artefact due to poor estimate of the ortholog distribution peaks")
+        logging.warning(f"used as input values for the rate-adjustment formulas.")
+        logging.warning("")
+        logging.warning("Poor peak estimation is often due to the very old divergence age between")
+        logging.warning(f"the two chosen species and/or outgroup, or by bad genome/sequence quality.")
+        logging.warning("It is thus recommended to visually check the quality of the ortholog distributions and their peak estimates")
+        logging.warning(f"in the 'orthologs_species1_species2.pdf' output files.")
         logging.warning("")
         logging.warning("TIPS! Try rerunning your analysis with one or more of the following changes:")
-        logging.warning(" - limit the number of outgroups by decreasing 'max_number_outgroups' (default is 4)")
-        logging.warning(" - set 'consensus_mode_for_multiple_outgroups' to 'best outgroup'")
-        logging.warning(" - exclude very old divergences from the input phylogeny")
+        logging.warning(" - limit the number of distant outgroups by decreasing 'max_number_outgroups' (default is 4)")
+        logging.warning(" - set 'consensus_mode_for_multiple_outgroups' to 'best outgroup' (see Documentation)")
+        logging.warning(" - remove species responsible for very old divergences in the input phylogeny")
         logging.warning("")
 
     return rel_rate_species, rel_rate_species_sd, rel_rate_sister, rel_rate_sister_sd


### PR DESCRIPTION
During rate-adjustment, ksrates prints a warning if there are negative values for Ks distances, stating that they are artefacts.
More details below.

The rate-adjusted ortholog peak (K_AB) is derived through the following mathematical formulas, using three estimated ortholog distribution peaks (A: focal species, B: sister species, C: outgroup):
<img width="589" alt="image" src="https://github.com/VIB-PSB/ksrates/assets/57489957/cb8fe586-fb2a-4045-9c7a-fe05b59bc043">
<img width="594" alt="image" src="https://github.com/VIB-PSB/ksrates/assets/57489957/e6b3f401-ba1a-4425-91c2-af8c14b1b072">

The numerator in (2) should always in principle be a positive number, as it is a measure of genetic distance. However, poor peak estimate for the three AC, AB and BC ortholog distributions might produce a negative sum, and therefore a negative K_OA value. The negative sign is then maintained also in (4).
Poor peak estimate is often due to the very old divergence age between the involved species or by bad quality sequence data.



