### PR TITLE
Supporting new Nextflow DSL2 syntax

### DIFF
--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           cd test
           mv nextflow.config custom_nextflow.config
-          NXF_VER=21.10.6 nextflow run ../main.nf --config config_elaeis.txt -with-docker ksrates
+          nextflow run ../main.nf --config config_elaeis.txt -with-docker ksrates
         
       - name: Visualize output files
         if: ${{ always() }}

--- a/main.nf
+++ b/main.nf
@@ -369,7 +369,7 @@ process checkConfig {
         echo ""
         echo -n "Configuration file [${config}] not found: it will now be generated... "
 
-        python3 /home/cesen/ksrates/ksrates_cli.py generate-config ${config} >> \$processDir/generate_config.txt
+        ksrates generate-config ${config} >> \$processDir/generate_config.txt
         RET_CODE=\$?
         echo "done [\${RET_CODE}]"
 
@@ -460,7 +460,7 @@ process setupAdjustment {
     echo -n "Extracting ortholog species pairs and trios from Newick tree... "
     echo "NF internal work directory for [setupAdjustment] process:\n\$processDir\n" > \${logs_folder}/${logs_names["setupAdjustment"]}
 
-    python3 /home/cesen/ksrates/ksrates_cli.py init ${config_args} --nextflow >> \${logs_folder}/${logs_names["setupAdjustment"]} 2>&1
+    ksrates init ${config_args} --nextflow >> \${logs_folder}/${logs_names["setupAdjustment"]} 2>&1
 
     RET_CODE=\$?
     echo "done [\${RET_CODE}]"
@@ -687,7 +687,7 @@ process estimatePeaks {
 
     echo "Updating ortholog peak database" >> $logs_folder/${logs_names["estimatePeaks"]}
 
-    python3 /home/cesen/ksrates/ksrates_cli.py orthologs-analysis ${config_args} --ortholog-pairs=\$processDir/$species_pairs_for_peak >> $logs_folder/${logs_names["estimatePeaks"]} 2>&1
+    ksrates orthologs-analysis ${config_args} --ortholog-pairs=\$processDir/$species_pairs_for_peak >> $logs_folder/${logs_names["estimatePeaks"]} 2>&1
 
     RET_CODE=\$?
     echo "done [\${RET_CODE}] `date "+%T"`"
@@ -732,7 +732,7 @@ process wgdParalogs {
 
     echo "Using ${task.cpus} thread(s)\n">> $logs_folder/${logs_names["wgdParalogs"]}
 
-    python3 /home/cesen/ksrates/ksrates_cli.py paralogs-ks ${config_args} --n-threads=${task.cpus} >> $logs_folder/${logs_names["wgdParalogs"]} 2>&1
+    ksrates paralogs-ks ${config_args} --n-threads=${task.cpus} >> $logs_folder/${logs_names["wgdParalogs"]} 2>&1
 
     RET_CODE=\$?
     echo "done [\${RET_CODE}] `date "+%T"`"
@@ -776,7 +776,7 @@ process wgdOrthologs {
 
     echo "Using ${task.cpus} thread(s)\n">> $logs_folder/${logs_names["wgdOrthologs"]}${species1}_${species2}.log
 
-    python3 /home/cesen/ksrates/ksrates_cli.py orthologs-ks ${config_args} $species1 $species2 --n-threads=${task.cpus} >> $logs_folder/${logs_names["wgdOrthologs"]}${species1}_${species2}.log 2>&1
+    ksrates orthologs-ks ${config_args} $species1 $species2 --n-threads=${task.cpus} >> $logs_folder/${logs_names["wgdOrthologs"]}${species1}_${species2}.log 2>&1
 
     RET_CODE=\$?
     echo "done [\${RET_CODE}] `date "+%T"`"
@@ -785,7 +785,7 @@ process wgdOrthologs {
     echo "\n" >> $logs_folder/${logs_names["wgdOrthologs"]}${species1}_${species2}.log
     echo "Species1\tSpecies2\n$species1\t$species2" > \${processDir}/tmp_${species1}_${species2}.txt
     
-    python3 /home/cesen/ksrates/ksrates_cli.py orthologs-analysis ${config_args} --ortholog-pairs=\${processDir}/tmp_${species1}_${species2}.txt >> $logs_folder/${logs_names["wgdOrthologs"]}${species1}_${species2}.log 2>&1
+    ksrates orthologs-analysis ${config_args} --ortholog-pairs=\${processDir}/tmp_${species1}_${species2}.txt >> $logs_folder/${logs_names["wgdOrthologs"]}${species1}_${species2}.log 2>&1
 
     RET_CODE=\$?
     echo "done [\${RET_CODE}] `date "+%T"`"
@@ -842,7 +842,7 @@ process plotOrthologDistrib {
     cd $PWD
     echo "NF internal work directory for [plotOrthologDistrib] process:\n\$processDir\n" > $logs_folder/${logs_names["plotOrthologDistrib"]}
 
-    python3 /home/cesen/ksrates/ksrates_cli.py plot-orthologs ${config_args} >> $logs_folder/${logs_names["plotOrthologDistrib"]} 2>&1
+    ksrates plot-orthologs ${config_args} >> $logs_folder/${logs_names["plotOrthologDistrib"]} 2>&1
     
     RET_CODE=\$?
     echo "done [\${RET_CODE}] `date "+%T"`"
@@ -919,7 +919,7 @@ process doRateAdjustment {
 
     echo -n "`date "+%T"` Starting rate-adjustment analysis... "
 
-    python3 /home/cesen/ksrates/ksrates_cli.py orthologs-adjustment ${config_args} >> $logs_folder/${logs_names["doRateAdjustment"]} 2>&1
+    ksrates orthologs-adjustment ${config_args} >> $logs_folder/${logs_names["doRateAdjustment"]} 2>&1
 
     RET_CODE=\$?
     echo "done [\${RET_CODE}] `date "+%T"`"
@@ -928,7 +928,7 @@ process doRateAdjustment {
 
     echo -n "`date "+%T"` Plotting mixed distributions... "
 
-    python3 /home/cesen/ksrates/ksrates_cli.py plot-paralogs ${config_args} >> $logs_folder/${logs_names["doRateAdjustment"]} 2>&1
+    ksrates plot-paralogs ${config_args} >> $logs_folder/${logs_names["doRateAdjustment"]} 2>&1
     
     RET_CODE=\$?
     echo "done [\${RET_CODE}] `date "+%T"`"
@@ -971,7 +971,7 @@ process paralogsAnalyses {
     cd $PWD
     echo "NF internal work directory for [paralogsAnalyses (${task.index})] process:\n\$processDir\n" >> $logs_folder/${logs_names["paralogsAnalyses"]}
 
-    python3 /home/cesen/ksrates/ksrates_cli.py paralogs-analyses ${config_args} >> $logs_folder/${logs_names["paralogsAnalyses"]} 2>&1
+    ksrates paralogs-analyses ${config_args} >> $logs_folder/${logs_names["paralogsAnalyses"]} 2>&1
  
     RET_CODE=\$?
     echo "done [\${RET_CODE}] `date "+%T"`"
@@ -1017,7 +1017,7 @@ process drawTree {
     cd $PWD
     echo "NF internal work directory for [drawTree] process:\n\$processDir\n" >> $logs_folder/${logs_names["drawTree"]}
 
-    python3 /home/cesen/ksrates/ksrates_cli.py plot-tree ${config_args} --nextflow >> $logs_folder/${logs_names["drawTree"]} 2>&1
+    ksrates plot-tree ${config_args} --nextflow >> $logs_folder/${logs_names["drawTree"]} 2>&1
 
     RET_CODE=\$?
     echo "done [\${RET_CODE}] `date "+%T"`"


### PR DESCRIPTION
This PR makes the Nextflow pipeline file (`main.nf`) in `ksrates` compatible with the recent [Nextflow DSL2 syntax](https://www.nextflow.io/docs/latest/dsl2.html), which has replaced the older DSL1 since version `22.03.0-edge`.
Based on my experience, current Nextflow versions (e.g. `23.04.1`) do not support DSL1 anymore, even when specifically setting it from command line (`-dsl1`) or in the configuration file.

With the changes in this PR, the Nextflow pipeline has been successfully executed on the `test` dataset, but further testing is required to make sure that all building blocks of the pipeline ('processes') are still correctly wired.

Notes concerning the [migration to DSL2 syntax](https://www.nextflow.io/docs/latest/dsl2.html#process): this mainly involves defining an extra block of code called `workflow` where processes are called; process input and output are provided/retrieved directly in this block. Therefore, all `from` and `into` connections within process definition blocks are removed.

Other related changes: YML file (`.github/workflows/test_pipeline.yml`) for CI in GitHub also updated by not asking Nextflow to run an older version compatible with DSL1.

TODO:
- [ ] To be linked to related issue and previous PR
- [ ] Update documentation about compatibility with DSL1 and DSL2