### PR TITLE
Drop linux/arm64 when pushing container to DockerHub

### DIFF
--- a/.github/workflows/push_container.yml
+++ b/.github/workflows/push_container.yml
@@ -39,6 +39,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          platforms: linux/arm64,linux/amd64
+          platforms: linux/amd64
           context: .
           tags: ${{ steps.meta.outputs.tags }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ configparser==5.0.2
 ete3==3.1.2
 pandas==1.3.2
 scikit-learn==0.24.2
-PyQt5==5.15.2
+PyQt5==5.15.11
 biopython==1.79
 coloredlogs==15.0.1
 fastcluster==1.1.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ configparser==5.0.2
 ete3==3.1.2
 pandas==1.3.2
 scikit-learn==0.24.2
-PyQt5==5.15.11
+PyQt5==5.15.2
 biopython==1.79
 coloredlogs==15.0.1
 fastcluster==1.1.25


### PR DESCRIPTION
Previously, the GitHub action building the container to be pushed to DockerHub supported both `linux/amd64` and `linux/arm64` platforms (see `push_container.yml`); however, for some reasons I don't understand yet, now PQt5 gives an error because it doesn't find a wheel for linux _arm_ and tries to compile it from source (but `qmake` is not installed and it fails). Note that I tried to use both PyQt5 `5.12.2` (version used in previous ksrates versions) and the latest `5.12.11`.

Building from source takes much time and it is not ideal, so I will drop the linux arm support; probably the linux _amd_ platform is the only one used by users. Should somebody need linux _arm_, I will look again into this.
Same will hold for future ksrates versions (v2.x.x).
