### PR TITLE
Fixes before v2 release (GitHub actions, Dockerfile, fastcluster)

### DIFF
--- a/.github/workflows/push_container.yml
+++ b/.github/workflows/push_container.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
 
       - name: Checkout

--- a/.github/workflows/push_container.yml
+++ b/.github/workflows/push_container.yml
@@ -19,7 +19,8 @@ jobs:
           images: |
             Cecilia-Sensalari/ksrates
           tags: |
-            type=ref,pattern={{version}}-{{gitref}}
+            type=ref,event=branch
+            type=sha
       
       - name: Login to DockerHub
         uses: docker/login-action@v1 

--- a/.github/workflows/push_container.yml
+++ b/.github/workflows/push_container.yml
@@ -1,6 +1,8 @@
 name: Push DockerHub CI
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:
@@ -17,10 +19,9 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            cesen/ksrates
+            vibpsb/ksrates
           tags: |
-            type=ref,event=branch
-            type=sha
+            type=ref,event=tag
       
       - name: Login to DockerHub
         uses: docker/login-action@v1 

--- a/.github/workflows/push_container.yml
+++ b/.github/workflows/push_container.yml
@@ -1,8 +1,6 @@
 name: Push DockerHub CI
 
 on:
-  push:
-    branches: [ v2 ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/push_container.yml
+++ b/.github/workflows/push_container.yml
@@ -38,6 +38,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          platforms: linux/arm64,linux/amd64
+          platforms: linux/amd64
           context: .
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/push_container.yml
+++ b/.github/workflows/push_container.yml
@@ -38,6 +38,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          platforms: linux/amd64
+          platforms: linux/arm64,linux/amd64
           context: .
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/push_container.yml
+++ b/.github/workflows/push_container.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
 
       - name: Checkout

--- a/.github/workflows/push_container.yml
+++ b/.github/workflows/push_container.yml
@@ -19,7 +19,7 @@ jobs:
           images: |
             Cecilia-Sensalari/ksrates
           tags: |
-            type=ref,event=tag
+            type=ref,pattern={{version}}-{{gitref}}
       
       - name: Login to DockerHub
         uses: docker/login-action@v1 

--- a/.github/workflows/push_container.yml
+++ b/.github/workflows/push_container.yml
@@ -17,7 +17,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            Cecilia-Sensalari/ksrates
+            cesen/ksrates
           tags: |
             type=ref,event=branch
             type=sha

--- a/.github/workflows/push_container.yml
+++ b/.github/workflows/push_container.yml
@@ -1,8 +1,8 @@
 name: Push DockerHub CI
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [ v2 ]
   workflow_dispatch:
 
 jobs:
@@ -19,7 +19,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            vibpsb/ksrates
+            Cecilia-Sensalari/ksrates
           tags: |
             type=ref,event=tag
       

--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Installing Nextflow
         run: |
           sudo apt-get update
-          sudo apt-get install wget default-jdk
+          sudo apt-get install wget openjdk-17-jdk
           sudo wget -qO- https://get.nextflow.io | bash
           sudo mv nextflow /usr/bin
             

--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -26,13 +26,16 @@ jobs:
         # Builds here the Docker container
         run: docker build . --file Dockerfile --tag ksrates
 
+      - name: Set Java 17 Environment
+        run: |
+          echo "JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64" >> $GITHUB_ENV
+          echo "/usr/lib/jvm/java-17-openjdk-amd64/bin" >> $GITHUB_PATH
+
       - name: Installing Nextflow
         run: |
           sudo apt-get update
           sudo apt-get install wget openjdk-17-jdk
-          echo "JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64" >> $GITHUB_ENV
-          echo "PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH" >> $GITHUB_ENV
-          sudo wget -qO- https://get.nextflow.io | bash
+          wget -qO- https://get.nextflow.io | bash
           sudo mv nextflow /usr/bin
             
       - name: Running ksrates Nextflow pipeline

--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -30,6 +30,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install wget openjdk-17-jdk
+          echo "JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64" >> $GITHUB_ENV
+          echo "PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH" >> $GITHUB_ENV
           sudo wget -qO- https://get.nextflow.io | bash
           sudo mv nextflow /usr/bin
             

--- a/.github/workflows/test_pipeline.yml
+++ b/.github/workflows/test_pipeline.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install wget openjdk-17-jdk
-          wget -qO- https://get.nextflow.io | bash
+          sudo wget -qO- https://get.nextflow.io | bash
           sudo mv nextflow /usr/bin
             
       - name: Running ksrates Nextflow pipeline

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -yq \
     wget \
     git \
     curl \
-    openjdk-17-jdk \
+    default-jdk \
     build-essential \
     mcl \
     ncbi-blast+ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,6 @@ ADD /wgd_ksrates /ksrates/wgd_ksrates
 ADD /README.md /ksrates/README.md
 ADD /ksrates_cli.py /ksrates/ksrates_cli.py
 
-# Install ksrates and requirements from requirements.txt, with isolated build
-# RUN python3.9 -m pip install --no-cache-dir --isolated /ksrates && \
-# 	rm -r /ksrates
+# Install ksrates and requirements from requirements.txt
+RUN python3.9 -m pip install /ksrates && \
+	rm -r /ksrates

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,5 +55,5 @@ ADD /README.md /ksrates/README.md
 ADD /ksrates_cli.py /ksrates/ksrates_cli.py
 
 # Install ksrates and requirements from requirements.txt, with isolated build
-RUN python3.9 -m pip install --no-cache-dir --isolated /ksrates && \
-	rm -r /ksrates
+# RUN python3.9 -m pip install --no-cache-dir --isolated /ksrates && \
+# 	rm -r /ksrates

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install Python3.9
+# Install Python 3.9
 RUN apt-get update && \
     apt-get install -y software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa && \
@@ -16,20 +16,32 @@ RUN apt-get update && \
 	python3.9 -m pip install --upgrade pip
 
 # Install non-python wgd dependencies
-RUN apt-get install -yq git curl default-jdk build-essential mcl ncbi-blast+ muscle fasttree 
+RUN apt-get update && apt-get install \
+    git \
+    curl \
+    default-jdk \
+    build-essential \
+    mcl \
+    ncbi-blast+ \
+    muscle \
+    fasttree
 
 # Install PAML from source
-RUN apt-get install -y wget && wget http://abacus.gene.ucl.ac.uk/software/paml4.9j.tgz && \
-	tar -xzf paml4.9j.tgz && cd paml4.9j/src && make -f Makefile && mv codeml /bin && cd /
+RUN apt-get update && apt-get install -y wget && \
+    wget http://abacus.gene.ucl.ac.uk/software/paml4.9j.tgz && \
+    tar -xzf paml4.9j.tgz && cd paml4.9j/src && make -f Makefile && \
+    mv codeml /bin && cd /
 
 # Install DIAMOND
-RUN	wget http://github.com/bbuchfink/diamond/releases/download/v2.1.9/diamond-linux64.tar.gz && \
-	tar -xzf diamond-linux64.tar.gz && mv diamond /bin
+RUN apt-get update && apt-get install -y wget && \
+    wget http://github.com/bbuchfink/diamond/releases/download/v2.1.9/diamond-linux64.tar.gz && \
+    tar -xzf diamond-linux64.tar.gz && mv diamond /bin
 
 # Install OrthoMCLight
-RUN wget https://raw.githubusercontent.com/VIB-PSB/OrthoMCLight/main/orthomclight.pl -P /bin && \
-	wget https://raw.githubusercontent.com/VIB-PSB/OrthoMCLight/main/orthomclight_module.pm -P /bin && \
-	chmod a+rx /usr/bin/orthomclight*
+RUN apt-get update && apt-get install -y wget && \
+    wget https://raw.githubusercontent.com/VIB-PSB/OrthoMCLight/main/orthomclight.pl -P /bin && \
+    wget https://raw.githubusercontent.com/VIB-PSB/OrthoMCLight/main/orthomclight_module.pm -P /bin && \
+    chmod a+rx /usr/bin/orthomclight*
 
 # Download the 37 angiosperm sequence zipped file from Zenodo for the reciprocal retention pipeline
 RUN wget https://zenodo.org/records/15225340/files/original_angiosperm_sequences.tar.gz -P /ksrates/reciprocal_retention

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     apt-get install -y software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
-    apt-get install -y python3.9 python3.9-distutils python3.9-dev && \
+    apt-get install -y python3.9 python3.9-distutils && \
 	curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9 && \
 	python3.9 -m pip install --upgrade pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,6 @@ ADD /wgd_ksrates /ksrates/wgd_ksrates
 ADD /README.md /ksrates/README.md
 ADD /ksrates_cli.py /ksrates/ksrates_cli.py
 
-# Install ksrates and requirements from requirements.txt
-RUN python3.9 -m pip install /ksrates && \
+# Install ksrates and requirements from requirements.txt, with isolated build
+RUN python3.9 -m pip install --no-cache-dir --isolated /ksrates && \
 	rm -r /ksrates

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     apt-get install -y software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
-    apt-get install -y python3.9 python3.9-distutils && \
+    apt-get install -y python3.9 python3.9-distutils python3.9-dev && \
 	curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9 && \
 	python3.9 -m pip install --upgrade pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,5 @@ ADD /README.md /ksrates/README.md
 ADD /ksrates_cli.py /ksrates/ksrates_cli.py
 
 # Install ksrates and requirements from requirements.txt
-RUN python3.9 -m pip install -r /ksrates/requirements.txt && \
-    python3.9 -m pip install /ksrates && \
+RUN python3.9 -m pip install /ksrates && \
     rm -r /ksrates

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,5 @@ ADD /README.md /ksrates/README.md
 ADD /ksrates_cli.py /ksrates/ksrates_cli.py
 
 # Install ksrates and requirements from requirements.txt
-RUN python3.9 -m pip install -r /ksrates/requirements.txt
-
-# Then install ksrates package itself
-RUN python3.9 -m pip install /ksrates && rm -r /ksrates
+RUN python3.9 -m pip install /ksrates && \
+	rm -r /ksrates

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,5 +53,6 @@ ADD /README.md /ksrates/README.md
 ADD /ksrates_cli.py /ksrates/ksrates_cli.py
 
 # Install ksrates and requirements from requirements.txt
-RUN python3.9 -m pip install /ksrates && \
+RUN python3.9 -m pip install -r /ksrates/requirements.txt && \
+    python3.9 -m pip install /ksrates && \
     rm -r /ksrates

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
 	python3.9 -m pip install --upgrade pip
 
 # Install non-python wgd dependencies
-RUN apt-get update && apt-get install \
+RUN apt-get update && apt-get install -yq \
     git \
     curl \
     default-jdk \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -yq \
     wget \
     git \
     curl \
-    default-jdk \
+    openjdk-17-jdk \
     build-essential \
     mcl \
     ncbi-blast+ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,5 +53,6 @@ ADD /README.md /ksrates/README.md
 ADD /ksrates_cli.py /ksrates/ksrates_cli.py
 
 # Install ksrates and requirements from requirements.txt
-RUN python3.9 -m pip install /ksrates && \
-	rm -r /ksrates
+RUN python3.9 -m pip install -r /ksrates/requirements.txt && \
+    python3.9 -m pip install /ksrates && \
+    rm -r /ksrates

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && \
 
 # Install non-python wgd dependencies
 RUN apt-get update && apt-get install -yq \
+    wget \
     git \
     curl \
     default-jdk \
@@ -27,19 +28,16 @@ RUN apt-get update && apt-get install -yq \
     fasttree
 
 # Install PAML from source
-RUN apt-get update && apt-get install -y wget && \
-    wget http://abacus.gene.ucl.ac.uk/software/paml4.9j.tgz && \
+RUN wget http://abacus.gene.ucl.ac.uk/software/paml4.9j.tgz && \
     tar -xzf paml4.9j.tgz && cd paml4.9j/src && make -f Makefile && \
     mv codeml /bin && cd /
 
 # Install DIAMOND
-RUN apt-get update && apt-get install -y wget && \
-    wget http://github.com/bbuchfink/diamond/releases/download/v2.1.9/diamond-linux64.tar.gz && \
+RUN wget http://github.com/bbuchfink/diamond/releases/download/v2.1.9/diamond-linux64.tar.gz && \
     tar -xzf diamond-linux64.tar.gz && mv diamond /bin
 
 # Install OrthoMCLight
-RUN apt-get update && apt-get install -y wget && \
-    wget https://raw.githubusercontent.com/VIB-PSB/OrthoMCLight/main/orthomclight.pl -P /bin && \
+RUN wget https://raw.githubusercontent.com/VIB-PSB/OrthoMCLight/main/orthomclight.pl -P /bin && \
     wget https://raw.githubusercontent.com/VIB-PSB/OrthoMCLight/main/orthomclight_module.pm -P /bin && \
     chmod a+rx /usr/bin/orthomclight*
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ coloredlogs==15.0.1
 plumbum==1.8.1
 progressbar2==3.53.1
 bokeh==1.4.0
-fastcluster==1.1.27
+fastcluster==1.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ pandas==1.4.3
 openpyxl==3.1.2
 scikit-learn==1.3.2
 PyQt5==5.15.11
-fastcluster==1.1.26
 joblib==1.3.2
 biopython==1.80
 coloredlogs==15.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ coloredlogs==15.0.1
 plumbum==1.8.1
 progressbar2==3.53.1
 bokeh==1.4.0
+fastcluster==1.1.27


### PR DESCRIPTION
**GitHub action `push_container.yml`:**
- Drop `linux/arm64` because it generates error related to PyQt5 not finding a wheel for linux _arm_ and attempting to build from source

**GitHub action `test_pipeline.yml`:**
- Set up Java 17 Environment
- Using `openjdk-17-jdk` instead of `default-jdk`

**`Dockerfile`:**
- Tidy up command layout
- Use a single RUN command to install ksrates and `requirements.txt`

**`requirements.txt`:**
- Upgrade `fastcluster` to `1.2.2` to have a linux wheel available for Python 3.9